### PR TITLE
Add OS and IDE files to the gitignore + Add documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+## Add all gitignores
+!**/.gitignore
+!.gitignore
+## Empty folders which should be kept
+!**/.keep
+!.keep
+
 #### OS
 ### Mac OS
 ## macOS system files

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,37 @@
+#### OS
+### Mac OS
+## macOS system files
 .DS_Store
+
+##### Development
+#### Node
+## Node.js dependencies directory
 node_modules/
+## Build directories
 dist/
 src/public/app-dist/
+## Log files generated
 npm-debug.log
 yarn-error.log
+## Databases
 *.db
+## Keys & Certs
 config.ini
 cert.key
 cert.crt
+## Server-specific package.json
 server-package.json
+#### ESLInt
+## Cache
+.eslintcache
+### Tmp files
+tmp/
+
+##### IDEs
+#### JetBrains
 .idea/httpRequests/
+
+## ---------------------
+
 data/
 data-test/
-tmp/
-.eslintcache

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,25 @@ tmp/
 
 ##### IDEs
 #### JetBrains
-.idea/httpRequests/
+## Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+## Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+**/.idea/*
+!**/.idea/.gitignore
+#### VisualStudioCode / VSCode / VSCodium
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+## Local History for Visual Studio Code
+.history/
+## Built Visual Studio Code Extensions
+*.vsix
+#### Kate template
+## Swap Files
+.*.kate-swp
+.swp.*
 
 ## ---------------------
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,39 @@
 
 #### OS
 ### Mac OS
+## General
 ## macOS system files
 .DS_Store
+.AppleDouble
+.LSOverride
+## Icon must end with two \r
+Icon
+## Thumbnails
+._*
+## Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+## Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+### Linux template
+*~
+## temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+## KDE directory preferences
+.directory
+## Linux trash folder which might appear on any partition or disk
+.Trash-*
+## .nfs files are created when an open file is removed but is still being accessed
+.nfs*
 
 ##### Development
 #### Node

--- a/src/.idea/.gitignore
+++ b/src/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/


### PR DESCRIPTION
Hope it helps leaving it more organized and complete.

- Grouped al files and folder by category
- Left comments about what is ignored or un-ignored
- Ignored/Un-ignored common files for:
  - OS:
    - Mac OS
    - Linux (+ KDE `.directory`)
  - IDEs/Editors
    - VS Code, Visual Studio Code, VS Codium
    - Most of the Jetbrains IDE (ignored almost the whole folder `/.idea` as is usually not needed)
    - Kate
